### PR TITLE
Build protoc from source if the pre-built binary won't work

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    protoc (2.6.1)
+    protoc (2.6.1.1)
       Platform (~> 0.4)
 
 GEM
@@ -21,4 +21,4 @@ DEPENDENCIES
   rubygems-tasks (~> 0.2)
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/bin/protoc
+++ b/bin/protoc
@@ -16,7 +16,7 @@ def platform_arch
 end
 
 def exec_protoc_for_os(os)
-  exec("#{File.dirname(__FILE__)}/protoc-#{Protoc::VERSION}-#{os}-#{PLATFORM_TO_PROTOC_ARCH[platform_arch]}.exe", *ARGV)
+  exec("#{File.dirname(__FILE__)}/protoc-#{Protoc::PROTOBUF_VERSION}-#{os}-#{PLATFORM_TO_PROTOC_ARCH[platform_arch]}.exe", *ARGV)
 end
 
 case Platform::OS

--- a/ext/protoc/Makefile
+++ b/ext/protoc/Makefile
@@ -1,0 +1,8 @@
+# This is a dummy makefile that will get used to build this "extension" when
+# the pre-built protoc will work on the system
+# This file will get overwritten by extconf.rb if it needs to build protoc
+# from source
+
+build:
+
+install:

--- a/ext/protoc/Makefile.in
+++ b/ext/protoc/Makefile.in
@@ -1,0 +1,24 @@
+PROTOBUF_VERSION = @PROTOBUF_VERSION@
+PROTOC_BINARY_PATH = @PROTOC_BINARY_PATH@
+
+build: stage/bin/protoc
+
+protobuf-$(PROTOBUF_VERSION):
+	curl -L https://github.com/google/protobuf/archive/v$(PROTOBUF_VERSION).tar.gz | tar xz
+
+protobuf-$(PROTOBUF_VERSION)/configure: | protobuf-$(PROTOBUF_VERSION)
+	cd protobuf-$(PROTOBUF_VERSION) && \
+	autoreconf -f -i -Wall,no-obsolete && \
+	rm -rf autom4te.cache config.h.in~
+
+protobuf-$(PROTOBUF_VERSION)/Makefile: protobuf-$(PROTOBUF_VERSION)/configure
+	cd protobuf-$(PROTOBUF_VERSION) && \
+	./configure --prefix=$(shell pwd)/stage --disable-shared
+
+stage/bin/protoc: protobuf-$(PROTOBUF_VERSION)/Makefile
+	cd protobuf-$(PROTOBUF_VERSION) && \
+	$(MAKE) install
+
+install: stage/bin/protoc
+	mv -f stage/bin/protoc $(PROTOC_BINARY_PATH)
+	rm -rf protobuf-$(PROTOBUF_VERSION) stage

--- a/ext/protoc/extconf.rb
+++ b/ext/protoc/extconf.rb
@@ -1,0 +1,45 @@
+require 'platform'
+require_relative '../../lib/protoc/version'
+
+PLATFORM_TO_PROTOC_ARCH = {:x86 => :x86_32, :x86_64 => :x86_64}
+
+# Work around for lack of x86_64 support in Platform 0.4.0, which is the
+# latest in rubygems.org. https://github.com/mmower/platform/issues/3
+def platform_arch
+  if Platform::ARCH == :unknown && RUBY_PLATFORM =~ /x86_64/
+    :x86_64
+  else
+    Platform::ARCH
+  end
+end
+
+OS = case Platform::OS
+       when :win32
+         'windows'
+       when :unix
+         case Platform::IMPL
+           when :macosx
+             'osx'
+           when :linux
+             'linux'
+           else
+             Platform::IMPL.to_s
+         end
+       else
+         Platform::OS.to_s
+     end
+
+HERE = File.expand_path(File.dirname(__FILE__))
+binpath = File.expand_path(File.join(HERE, '..', '..', 'bin'))
+protoc_path = File.join(
+  binpath, "protoc-#{Protoc::PROTOBUF_VERSION}-#{OS}-#{PLATFORM_TO_PROTOC_ARCH[platform_arch]}.exe"
+)
+`#{protoc_path} --version`
+if $? != 0 && OS != 'windows'
+  Dir.chdir(HERE) do
+    template = File.read(File.join(HERE, 'Makefile.in'))
+    template.gsub!('@PROTOBUF_VERSION@', Protoc::PROTOBUF_VERSION)
+    template.gsub!('@PROTOC_BINARY_PATH@', protoc_path)
+    File.write(File.join(HERE, 'Makefile'), template)
+  end
+end

--- a/lib/protoc/version.rb
+++ b/lib/protoc/version.rb
@@ -1,3 +1,6 @@
 module Protoc
-  VERSION = '2.6.1'
+  # The version of the protobuf library from which these protoc binaries were built
+  PROTOBUF_VERSION = '2.6.1'
+  # This gem's version
+  VERSION = PROTOBUF_VERSION + '.1'
 end

--- a/protoc-mingw32.gemspec
+++ b/protoc-mingw32.gemspec
@@ -1,0 +1,6 @@
+# coding: utf-8
+
+winspec = Gem::Specification.load('protoc.gemspec').dup
+winspec.extensions = nil
+winspec.platform = "universal-mingw32"
+winspec

--- a/protoc-mswin32.gemspec
+++ b/protoc-mswin32.gemspec
@@ -1,0 +1,6 @@
+# coding: utf-8
+
+winspec = Gem::Specification.load('protoc.gemspec').dup
+winspec.extensions = nil
+winspec.platform = "universal-mswin32"
+winspec

--- a/protoc.gemspec
+++ b/protoc.gemspec
@@ -15,8 +15,9 @@ of the version you need. By using this gem, you will not need to manually instal
   spec.homepage = 'https://github.com/Tripwire/protoc-gem'
   spec.license = 'BSD'
 
-  spec.files = Dir['{bin,lib}/**/*']
+  spec.files = Dir['{bin,lib,ext}/**/*']
   spec.executables = spec.files.grep(%r{^bin}) { |f| File.basename(f) }
+  spec.extensions = 'ext/protoc/extconf.rb'
 
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 11.0'


### PR DESCRIPTION
The pre-built linux binaries depend on GLIBC 2.14, which means they
won't work on older distributions.  This change will pull the protobuf
source from github and build the protoc binary if the pre-built one
won't run on the system.