### PR TITLE
Include protobuf source instead of downloading it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/protoc/protobuf"]
+	path = ext/protoc/protobuf
+	url = https://github.com/google/protobuf.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    protoc (2.6.1.1)
+    protoc (2.6.1.2)
       Platform (~> 0.4)
 
 GEM
@@ -21,4 +21,4 @@ DEPENDENCIES
   rubygems-tasks (~> 0.2)
 
 BUNDLED WITH
-   1.14.3
+   1.14.4

--- a/LICENSE
+++ b/LICENSE
@@ -3,6 +3,9 @@ This license applies to all parts of the protoc-gem source, except:
   * The protoc binaries included in this gem are part of Protocol
     Buffers, which are copyrighted by Google, Inc. and available
     under the license at lib/protoc/protocol_buffers_license.txt.
+  * The Protocol Buffers source code included with this gem is
+    copyrighted by Google, Inc. and available under the license at
+    ext/protoc/protobuf/LICENSE.
 
 Copyright (c) 2016, Tripwire, Inc.
 All rights reserved.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This gem includes protoc, the protobuf compiler, binaries for Linux, Mac, and Wi
 called `protoc` that picks the right one to run on your platform. You can use this gem to ensure that you have a protoc
 of the version you need. By using this gem, you will not need to manually install the right protoc on your hosts.
 
+The pre-built linux protoc binaries are not compatible with all systems.  For this reason the protobuf source code is
+included in this gem, and a new protoc binary is built upon gem installation when the pre-built one does not function.
+
 ## Suggested Use
 
 Put `protoc` in your Gemfile, with the version of protobuf that you need.

--- a/ext/protoc/Makefile.in
+++ b/ext/protoc/Makefile.in
@@ -1,24 +1,21 @@
-PROTOBUF_VERSION = @PROTOBUF_VERSION@
 PROTOC_BINARY_PATH = @PROTOC_BINARY_PATH@
 
 build: stage/bin/protoc
 
-protobuf-$(PROTOBUF_VERSION):
-	curl -L https://github.com/google/protobuf/archive/v$(PROTOBUF_VERSION).tar.gz | tar xz
-
-protobuf-$(PROTOBUF_VERSION)/configure: | protobuf-$(PROTOBUF_VERSION)
-	cd protobuf-$(PROTOBUF_VERSION) && \
+protobuf/configure:
+	cd protobuf && \
 	autoreconf -f -i -Wall,no-obsolete && \
 	rm -rf autom4te.cache config.h.in~
 
-protobuf-$(PROTOBUF_VERSION)/Makefile: protobuf-$(PROTOBUF_VERSION)/configure
-	cd protobuf-$(PROTOBUF_VERSION) && \
-	./configure --prefix=$(shell pwd)/stage --disable-shared
+protobuf/Makefile: protobuf/configure
+	cd protobuf && ./configure --prefix=$(shell pwd)/stage --disable-shared
 
-stage/bin/protoc: protobuf-$(PROTOBUF_VERSION)/Makefile
-	cd protobuf-$(PROTOBUF_VERSION) && \
-	$(MAKE) install
+stage/bin/protoc: protobuf/Makefile
+	cd protobuf && $(MAKE) install
 
 install: stage/bin/protoc
 	mv -f stage/bin/protoc $(PROTOC_BINARY_PATH)
-	rm -rf protobuf-$(PROTOBUF_VERSION) stage
+
+clean:
+	-rm -rf stage
+	cd protobuf && $(MAKE) clean

--- a/ext/protoc/extconf.rb
+++ b/ext/protoc/extconf.rb
@@ -38,7 +38,6 @@ protoc_path = File.join(
 if $? != 0 && OS != 'windows'
   Dir.chdir(HERE) do
     template = File.read(File.join(HERE, 'Makefile.in'))
-    template.gsub!('@PROTOBUF_VERSION@', Protoc::PROTOBUF_VERSION)
     template.gsub!('@PROTOC_BINARY_PATH@', protoc_path)
     File.write(File.join(HERE, 'Makefile'), template)
   end

--- a/lib/protoc/version.rb
+++ b/lib/protoc/version.rb
@@ -2,5 +2,5 @@ module Protoc
   # The version of the protobuf library from which these protoc binaries were built
   PROTOBUF_VERSION = '2.6.1'
   # This gem's version
-  VERSION = PROTOBUF_VERSION + '.1'
+  VERSION = PROTOBUF_VERSION + '.2'
 end

--- a/protoc-mingw32.gemspec
+++ b/protoc-mingw32.gemspec
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 winspec = Gem::Specification.load('protoc.gemspec').dup
+winspec.files = Dir['{bin,lib}/**/*']
 winspec.extensions = nil
 winspec.platform = "universal-mingw32"
 winspec

--- a/protoc-mswin32.gemspec
+++ b/protoc-mswin32.gemspec
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 winspec = Gem::Specification.load('protoc.gemspec').dup
+winspec.files = Dir['{bin,lib}/**/*']
 winspec.extensions = nil
 winspec.platform = "universal-mswin32"
 winspec

--- a/protoc.gemspec
+++ b/protoc.gemspec
@@ -9,9 +9,15 @@ Gem::Specification.new do |spec|
 
   spec.authors = 'Ben Jansen'
   spec.summary = 'Protoc binaries for Mac, Linux, and Windows'
-  spec.description = 'This gem includes protoc, the protobuf compiler, binaries for Linux, Mac, and Windows. It installs a executable shim
+  spec.description = <<EOF
+This gem includes protoc, the protobuf compiler, binaries for Linux, Mac, and Windows. It installs a executable shim
 called `protoc` that picks the right one to run on your platform. You can use this gem to ensure that you have a protoc
-of the version you need. By using this gem, you will not need to manually install the right protoc on your hosts.'
+of the version you need. By using this gem, you will not need to manually install the right protoc on your hosts.
+
+The pre-built linux protoc binaries are not compatible with all systems.  For this reason the protobuf source code is
+included in this gem, and a new protoc binary is built upon gem installation when the pre-built one does not function.
+EOF
+
   spec.homepage = 'https://github.com/Tripwire/protoc-gem'
   spec.license = 'BSD'
 


### PR DESCRIPTION
This PR switches from downloading the protobuf source tarball when building the "extension" to including the source in the gem.  This makes the gem self-contained and allows it to install on systems with restricted web access that can't reach github to pull the tarball.

It also includes some updates to the readme and gem description to mention that protoc may be built from source in some cases.