### PR TITLE
Adding an AIX binary for protoc 2.6.1.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    Platform (0.4.0)
+    Platform (0.4.1)
     rake (11.1.2)
     rubygems-tasks (0.2.4)
 

--- a/bin/protoc
+++ b/bin/protoc
@@ -3,7 +3,7 @@
 require 'platform'
 require 'protoc/version'
 
-PLATFORM_TO_PROTOC_ARCH = {:x86 => :x86_32, :x86_64 => :x86_64}
+PLATFORM_TO_PROTOC_ARCH = {:x86 => :x86_32, :x86_64 => :x86_64, :powerpc => :powerpc}
 
 # Work around for lack of x86_64 support in Platform 0.4.0, which is the
 # latest in rubygems.org. https://github.com/mmower/platform/issues/3

--- a/bin/protoc
+++ b/bin/protoc
@@ -28,6 +28,8 @@ case Platform::OS
         exec_protoc_for_os('osx')
       when :linux
         exec_protoc_for_os('linux')
+      when :aix
+        exec_protoc_for_os('aix')
       else
         raise "I don't have a binary for #{Platform::IMPL}"
     end


### PR DESCRIPTION
`MD5 (protoc-2.6.1-aix-.exe) = 23945207b57158d5353a48a366b8fda4`