### PR TITLE
Fix process-bitness detection in ruby / windows 64

### DIFF
--- a/bin/protoc
+++ b/bin/protoc
@@ -8,7 +8,7 @@ PLATFORM_TO_PROTOC_ARCH = {:x86 => :x86_32, :x86_64 => :x86_64, :powerpc => :pow
 # Work around for lack of x86_64 support in Platform 0.4.0, which is the
 # latest in rubygems.org. https://github.com/mmower/platform/issues/3
 def platform_arch
-  if Platform::ARCH == :unknown && RUBY_PLATFORM =~ /x86_64/
+  if Platform::ARCH == :unknown && RUBY_PLATFORM =~ /x86_64|x64/
     :x86_64
   else
     Platform::ARCH


### PR DESCRIPTION
The current process bitness detection fails in ruby / windows 64, returning an empty `#{PLATFORM_TO_PROTOC_ARCH[platform_arch]}`  and making https://github.com/javier-lopez/protoc-gem/blob/bd5fcdd31552638b6930f5918104e7116648661f/bin/protoc#L27 to fail